### PR TITLE
fix(build): switch from hatchling to setuptools for build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "boto3-utils"
-version = "1.3.0"
+version = "1.3.1"
 description = "Utilidades para trabajar con Boto3"
 readme = "README.md"
 authors = [
@@ -18,8 +18,8 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
 
 [dependency-groups]
 dev = ["ipython>=8.34.0", "ruff>=0.10.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 ]
 
 [build-system]
+# Setuptools is used only for compatibility with the old version of pip that AWS SAM uses
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
### Summary

This pull request updates the package version to 1.3.1 and modifies the build system to use `setuptools` instead of `hatchling`. A `setup.py` file has been added to ensure compatibility with older versions of `pip`, specifically those used by AWS SAM.

### Context

The primary motivation for this change is to address compatibility issues with AWS SAM, which relies on older versions of `pip`. By switching to `setuptools` and including a `setup.py` file, we ensure that the package can be correctly installed and used within the AWS SAM environment. This change also includes a version bump to reflect the update.